### PR TITLE
Simplifying event tests

### DIFF
--- a/events_test.go
+++ b/events_test.go
@@ -11,19 +11,9 @@ func TestCloseEventStream(t *testing.T) {
 	es := &SdlEventStream{}
 	events := es.Receive()
 	t.Log("Opened channel, calling close in background")
-	errc := make(chan error)
-	// do it in background to give it time
-	go func() {
-		errc <- es.Close()
-	}()
-	select {
-	case err := <-errc:
-		if err != nil {
-			t.Errorf("An error occured: %v", err)
-		}
-		// we have finished in time
-	case <-time.After(3 * time.Second):
-		t.Fatal("timeout!")
+	err := es.Close()
+	if err != nil {
+		t.Errorf("An error occured: %v", err)
 	}
 	if evt := <-events; evt != nil {
 		t.Errorf("events returned something other than it's zero value nil: %v", evt)
@@ -32,58 +22,39 @@ func TestCloseEventStream(t *testing.T) {
 
 func TestCloseEventSubscriber(t *testing.T) {
 	es := NewEventSubscriber()
-	errc := make(chan error)
-	go func() {
-		errc <- es.Close()
-	}()
-	select {
-	case err := <-errc:
-		if err != nil {
-			t.Errorf("closing returned error: %v", err)
-		}
-	case <-time.After(3 * time.Second):
-		t.Errorf("timeout!")
+	if err := es.Close(); err != nil {
+		t.Errorf("closing returned error: %v", err)
 	}
+
 }
 
 func TestReceiveSpecificKeyEvent(t *testing.T) {
-	done := make(chan bool)
-	go func() {
-		es := NewEventSubscriber()
-		t.Log("Subscribe")
-		evtChan := es.Subscribe(sdl.K_UP)
-		t.Log("Create Fake Event")
-		fakeEvent := &sdl.KeyDownEvent{
-			Keysym: sdl.Keysym{
-				Sym:      sdl.K_UP,
-				Scancode: sdl.SCANCODE_UP,
-				Mod:      sdl.KMOD_NONE,
-				Unicode:  0,
-			},
-			Type:      sdl.KEYDOWN,
-			Timestamp: 0,
-			WindowID:  0,
-			State:     sdl.PRESSED,
-			Repeat:    0,
-		}
-		t.Log("Push fake Event")
-		sdl.PushEvent(fakeEvent)
-		select {
-		case evt := <-evtChan:
-			switch e := evt.(type) {
-			case *sdl.KeyDownEvent:
-				if e.Keysym.Sym != sdl.K_UP {
-					t.Errorf("Key is %v instead of %v", e.Keysym.Sym, sdl.K_UP)
-				}
-			}
-		case <-time.After(5 * time.Second):
-			t.Error("timeout after 5 seconds")
-		}
-		done <- true
-	}()
+	es := NewEventSubscriber()
+	evtChan := es.Subscribe(sdl.K_UP)
+	fakeEvent := &sdl.KeyDownEvent{
+		Keysym: sdl.Keysym{
+			Sym:      sdl.K_UP,
+			Scancode: sdl.SCANCODE_UP,
+			Mod:      sdl.KMOD_NONE,
+			Unicode:  0,
+		},
+		Type:      sdl.KEYDOWN,
+		Timestamp: 0,
+		WindowID:  0,
+		State:     sdl.PRESSED,
+		Repeat:    0,
+	}
+	sdl.PushEvent(fakeEvent)
 	select {
-	case <-done:
-	case <-time.After(10 * time.Second):
-		t.Error("Timeout Nothing went well")
+	case evt := <-evtChan:
+		switch e := evt.(type) {
+		case *sdl.KeyDownEvent:
+			if e.Keysym.Sym != sdl.K_UP {
+				t.Errorf("Key is %v instead of %v", e.Keysym.Sym, sdl.K_UP)
+			}
+		}
+	// is this necessary?
+	case <-time.After(1 * time.Millisecond):
+		t.Error("timeout after 1 millisecond")
 	}
 }

--- a/events_test.go
+++ b/events_test.go
@@ -36,13 +36,9 @@ func TestReceiveSpecificKeyEvent(t *testing.T) {
 			Sym:      sdl.K_UP,
 			Scancode: sdl.SCANCODE_UP,
 			Mod:      sdl.KMOD_NONE,
-			Unicode:  0,
 		},
-		Type:      sdl.KEYDOWN,
-		Timestamp: 0,
-		WindowID:  0,
-		State:     sdl.PRESSED,
-		Repeat:    0,
+		Type:  sdl.KEYDOWN,
+		State: sdl.PRESSED,
 	}
 	sdl.PushEvent(fakeEvent)
 	select {

--- a/events_test.go
+++ b/events_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"github.com/veandco/go-sdl2/sdl"
 	"testing"
-	"time"
 )
 
 // TestCloseEventStream tests if closing our event stream works
@@ -41,16 +40,13 @@ func TestReceiveSpecificKeyEvent(t *testing.T) {
 		State: sdl.PRESSED,
 	}
 	sdl.PushEvent(fakeEvent)
-	select {
-	case evt := <-evtChan:
-		switch e := evt.(type) {
-		case *sdl.KeyDownEvent:
-			if e.Keysym.Sym != sdl.K_UP {
-				t.Errorf("Key is %v instead of %v", e.Keysym.Sym, sdl.K_UP)
-			}
+	evt := <-evtChan
+	switch e := evt.(type) {
+	case *sdl.KeyDownEvent:
+		if e.Keysym.Sym != sdl.K_UP {
+			t.Errorf("Key is %v instead of %v", e.Keysym.Sym, sdl.K_UP)
 		}
-	// is this necessary?
-	case <-time.After(1 * time.Millisecond):
-		t.Error("timeout after 1 millisecond")
+	default:
+		t.Errorf("Event was %v instead of KeyDownEvent", evt)
 	}
 }


### PR DESCRIPTION
Timeouts can be done via `go test -timeout 1s`

fix #4 
